### PR TITLE
fix(daily-brief): 修复生成与排行榜缺陷，加固外部调用并降低读放大

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,13 +55,24 @@ BRIEF_TOP_ITEMS_PER_SOURCE=10
 BRIEF_MAX_TOPICS=12
 # 股票历史排名接口缓存时长（秒，默认 12 小时）
 BRIEF_STOCK_RANKING_CACHE_TTL=43200
+# 简报卡在 generating 状态多久后视为失败并允许重新生成（分钟）
+BRIEF_GENERATING_TIMEOUT_MINUTES=30
+# 抓取热榜源时的最大并发数
+BRIEF_SOURCE_CONCURRENCY=3
+# 调用 Tavily 搜索时的最大并发数
+BRIEF_SEARCH_CONCURRENCY=3
 
 # OPENAI 配置
 OPENAI_API_KEY=skxxx
 OPENAI_API_BASE_URL=https://api.deepseek.com
 AI_MODEL=deepseek-v4-flash
+# 单次 AI 请求超时（毫秒）与重试次数
+AI_TIMEOUT_MS=120000
+AI_MAX_RETRIES=2
 
 # Tavily Search API Key
 # 从 https://tavily.com 获取你的API Key
 TAVILY_API_KEY=tvly-dev-xxx
 TAVILY_MAX_RESULTS=5
+# 单次 Tavily 搜索超时（毫秒）
+TAVILY_TIMEOUT_MS=10000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ Config is defined in:
 
 When adding a new environment variable, update all three places.
 
+Daily brief code must not call `ConfigService` directly. Read settings through `DailyBriefConfigService` (`src/daily-brief/daily-brief.config.ts`), which uses `getOrThrow` so defaults live only in `configuration.ts` / `validation.schema.ts`. When adding a daily brief variable, add a typed getter there too.
+
 Daily brief variables:
 
 ```bash
@@ -77,13 +79,19 @@ BRIEF_SOURCES=cls,yicai,wallstreet,jin10,tonghuashun,eastmoney,gelonghui
 BRIEF_LOOKBACK_HOURS=24
 BRIEF_TOP_ITEMS_PER_SOURCE=10
 BRIEF_MAX_TOPICS=12
+BRIEF_GENERATING_TIMEOUT_MINUTES=30
+BRIEF_SOURCE_CONCURRENCY=3
+BRIEF_SEARCH_CONCURRENCY=3
 
 OPENAI_API_KEY=skxxx
 OPENAI_API_BASE_URL=https://api.deepseek.com
 AI_MODEL=deepseek-v4-flash
+AI_TIMEOUT_MS=120000
+AI_MAX_RETRIES=2
 
 TAVILY_API_KEY=tvly-dev-xxx
 TAVILY_MAX_RESULTS=5
+TAVILY_TIMEOUT_MS=10000
 ```
 
 Do not print real API keys from `.env` in final responses or logs.
@@ -99,6 +107,9 @@ src/daily-brief/daily-brief.module.ts
 src/daily-brief/daily-brief.controller.ts
 src/daily-brief/daily-brief.service.ts
 src/daily-brief/daily-brief.scheduler.ts
+src/daily-brief/daily-brief.config.ts
+src/daily-brief/utils/brief-date.ts
+src/daily-brief/utils/concurrency.ts
 src/daily-brief/clients/ai-analysis.client.ts
 src/daily-brief/clients/tavily-search.client.ts
 src/daily-brief/interfaces/daily-brief.interface.ts
@@ -113,8 +124,12 @@ Behavior:
 - Refreshes configured hot list sources before generating.
 - Saves fetched hot items to the existing history repository.
 - Analyzes only the first `BRIEF_TOP_ITEMS_PER_SOURCE` items per source. Current default is 10.
-- Uses Tavily to enrich up to `BRIEF_MAX_TOPICS` candidate topics.
+- Uses Tavily to enrich up to `BRIEF_MAX_TOPICS` candidate topics, at most `BRIEF_SEARCH_CONCURRENCY` at a time.
 - Uses the OpenAI SDK with `OPENAI_API_BASE_URL` and `AI_MODEL`.
+- All external calls are bounded: `TAVILY_TIMEOUT_MS` per search, `AI_TIMEOUT_MS` / `AI_MAX_RETRIES` per analysis.
+- Rejects an analysis without a summary or without topics, so an empty AI response is recorded as `failed` rather than `success`.
+- A brief stuck in `generating` for longer than `BRIEF_GENERATING_TIMEOUT_MINUTES` is treated as stale and may be regenerated without `force`.
+- `GET /api/briefs/config` reports `enabled` from the scheduler's live state, so it reflects `scheduler/start` and `scheduler/stop`.
 - Saves generated briefs to MongoDB.
 - Stores `rawInputItems` and `searchEvidence` for backend debugging, but does not return them by default.
 
@@ -141,6 +156,8 @@ POST   /api/briefs/scheduler/start
 POST   /api/briefs/scheduler/stop
 POST   /api/briefs/scheduler/reconfigure
 ```
+
+No endpoint has built-in authentication. `POST /api/briefs/generate` (spends AI and Tavily quota), both `DELETE` routes, and the `scheduler/*` routes are expected to be restricted at the reverse proxy / gateway layer. Do not add auth to these without asking the maintainer first.
 
 Examples:
 
@@ -183,6 +200,8 @@ When adding a schema or repository:
 3. Add and export the repository from `DatabaseModule`.
 
 Daily brief collection has a unique index on `{ briefDate: 1, period: 1 }`.
+
+Aggregation pipelines must stay MongoDB 4.0 compatible. `src/database/repositories/mongo40-compatibility.spec.ts` extracts every operator the daily brief pipelines emit and fails on anything introduced after 4.0 (`$set`, `$replaceAll`, `$unionWith`, `$function`, `$getField`, …). Run it after touching any pipeline.
 
 ## Scheduler Notes
 

--- a/docs/guide/daily-brief.md
+++ b/docs/guide/daily-brief.md
@@ -31,15 +31,21 @@ BRIEF_LOOKBACK_HOURS=24
 BRIEF_TOP_ITEMS_PER_SOURCE=10
 BRIEF_MAX_TOPICS=12
 BRIEF_STOCK_RANKING_CACHE_TTL=43200
+BRIEF_GENERATING_TIMEOUT_MINUTES=30
+BRIEF_SOURCE_CONCURRENCY=3
+BRIEF_SEARCH_CONCURRENCY=3
 
 # OPENAI 配置
 OPENAI_API_KEY=skxxx
 OPENAI_API_BASE_URL=https://api.deepseek.com
 AI_MODEL=deepseek-v4-flash
+AI_TIMEOUT_MS=120000
+AI_MAX_RETRIES=2
 
 # Tavily Search API Key
 TAVILY_API_KEY=tvly-dev-xxx
 TAVILY_MAX_RESULTS=5
+TAVILY_TIMEOUT_MS=10000
 ```
 
 字段说明：
@@ -54,11 +60,17 @@ TAVILY_MAX_RESULTS=5
 | `BRIEF_TOP_ITEMS_PER_SOURCE` | 每个源最多纳入多少条热点，默认只分析前 10 条 |
 | `BRIEF_MAX_TOPICS` | 最多对多少个候选主题做 Tavily 搜索增强 |
 | `BRIEF_STOCK_RANKING_CACHE_TTL` | 股票历史排名接口缓存时长（秒），默认 `43200`（12 小时） |
+| `BRIEF_GENERATING_TIMEOUT_MINUTES` | 简报卡在 `generating` 多久后视为失败并允许重新生成，默认 `30` 分钟 |
+| `BRIEF_SOURCE_CONCURRENCY` | 抓取热榜源时的最大并发数，默认 `3` |
+| `BRIEF_SEARCH_CONCURRENCY` | 调用 Tavily 搜索时的最大并发数，默认 `3` |
 | `OPENAI_API_KEY` | OpenAI SDK 使用的 API Key |
 | `OPENAI_API_BASE_URL` | 兼容 OpenAI 协议的 API Base URL |
 | `AI_MODEL` | 生成简报使用的模型 |
+| `AI_TIMEOUT_MS` | 单次 AI 请求超时（毫秒），默认 `120000` |
+| `AI_MAX_RETRIES` | AI 请求失败重试次数，默认 `2`，设为 `0` 关闭重试 |
 | `TAVILY_API_KEY` | Tavily 搜索 API Key |
 | `TAVILY_MAX_RESULTS` | 每个搜索请求最多返回多少条结果 |
+| `TAVILY_TIMEOUT_MS` | 单次 Tavily 搜索超时（毫秒），默认 `10000` |
 
 ## 数据结构
 
@@ -103,6 +115,19 @@ TAVILY_MAX_RESULTS=5
 ```text
 http://localhost:6688
 ```
+
+::: warning 写接口没有内建鉴权
+服务本身不对任何接口做鉴权。下列接口会**消耗真实费用或删除数据**，必须在反向代理 / 网关层限制来源，不要直接暴露到公网：
+
+| 接口 | 风险 |
+| --- | --- |
+| `POST /api/briefs/generate` | 触发 AI 与 Tavily 调用，直接产生费用 |
+| `DELETE /api/briefs/:date` | 删除指定日期的简报 |
+| `DELETE /api/briefs/history` | 按条件批量删除历史简报 |
+| `POST /api/briefs/scheduler/start`<br>`POST /api/briefs/scheduler/stop`<br>`POST /api/briefs/scheduler/reconfigure` | 改变定时任务运行状态 |
+
+`GET` 接口只读，可以按需开放给前端。
+:::
 
 ### 获取简报配置
 
@@ -226,9 +251,25 @@ curl 'http://localhost:6688/api/briefs/statistics/stocks'
 curl 'http://localhost:6688/api/briefs/statistics/stocks?period=daily&startDate=2026-01-01&endDate=2026-07-18&limit=20'
 ```
 
-接口按完整查询条件缓存结果，默认缓存 12 小时。缓存复用现有缓存模块（Redis 不可用时降级为进程内存缓存）；成功生成简报或实际删除简报后，会清理股票排名缓存。
+接口按完整查询条件缓存结果，默认缓存 12 小时。缓存复用现有缓存模块（Redis 不可用时降级为进程内存缓存）；成功生成简报或实际删除简报后，会清理股票排名缓存（生成失败不会清，因为排名数据没有变化）。
+
+### 同一只股票的归并规则
+
+AI 给出的 `aShareMapping` 里，同一家公司在不同简报中可能写法不一致，聚合会先做归一化再统计：
+
+- **代码格式**：去掉 `.SH` / `.SZ` 之类的后缀，以及 `SH` / `SZ` / `BJ` 前缀。`600519`、`SH600519`、`600519.SH`、`sh600519` 视为同一只。
+- **有时带代码、有时不带**：先按公司名归并，把「带代码那次」学到的代码补给同一家公司的其他记录，再按代码归并。
+- **只有代码没有公司名**（`company` 为 `待验证` 等占位值）：也会并入同代码的那一条，并显示已知的公司名。
+- **始终没有代码**：按公司名单独成条，`code` 返回 `null`。
+- `appearanceCount` 统计出现次数（同一份简报里出现两次算两次），`briefCount` 统计去重后的简报数。
+
+公司名和代码取该股票**最近一次**出现时的有效值。
 
 股票排名聚合兼容 MongoDB 4.0：使用 `$addFields` 和 `$reduce`/`$split` 处理股票代码，不依赖 MongoDB 4.2/4.4 才提供的 `$set` 聚合阶段和 `$replaceAll` 表达式。
+
+简报列表接口（`GET /api/briefs`）的投影聚合同样兼容 4.0，用到的 `$$REMOVE`（3.6 引入）、`$ifNull`、`$size` 都在 4.0 可用范围内。
+
+这条约束由 `src/database/repositories/mongo40-compatibility.spec.ts` 守护：它把两条管道实际发出的算子全部抽出来，既检查没有出现 4.2/4.4/5.0 才有的算子，也用白名单确保不会悄悄引入未经确认的新算子。改动聚合管道后请保证该测试通过。
 
 查询参数：
 

--- a/src/cache/cache.service.spec.ts
+++ b/src/cache/cache.service.spec.ts
@@ -1,0 +1,76 @@
+import { CacheService } from './cache.service';
+
+describe('CacheService delByPattern', () => {
+  const ping = jest.fn().mockResolvedValue('PONG');
+  const del = jest.fn();
+  const keys = jest.fn();
+  const scanStream = jest.fn();
+  let service: CacheService;
+
+  const buildService = () =>
+    new CacheService(
+      { ping, del, keys, scanStream } as never,
+      { get: (_key: string, fallback: unknown) => fallback } as never,
+      { get: jest.fn(), set: jest.fn(), del: jest.fn() } as never,
+    );
+
+  /** 模拟 ioredis 的 scanStream：按批产出 key。 */
+  const streamOf = (batches: string[][]): AsyncIterable<string[]> => ({
+    async *[Symbol.asyncIterator]() {
+      for (const batch of batches) {
+        yield await Promise.resolve(batch);
+      }
+    },
+  });
+
+  beforeEach(async () => {
+    ping.mockClear();
+    del
+      .mockReset()
+      .mockImplementation((...args: string[]) => Promise.resolve(args.length));
+    keys.mockReset();
+    scanStream.mockReset();
+    service = buildService();
+    // 构造函数里的连接探测是异步的
+    await Promise.resolve();
+  });
+
+  it('scans with the prefix instead of calling KEYS', async () => {
+    scanStream.mockReturnValue(streamOf([['a:1', 'a:2']]));
+
+    await service.delByPattern('a:');
+
+    // KEYS 会阻塞整个 Redis 实例，必须不再被调用
+    expect(keys).not.toHaveBeenCalled();
+    expect(scanStream).toHaveBeenCalledWith({ match: 'a:*', count: 100 });
+  });
+
+  it('deletes every batch the scan yields', async () => {
+    scanStream.mockReturnValue(
+      streamOf([['a:1', 'a:2'], ['a:3'], [], ['a:4']]),
+    );
+
+    await service.delByPattern('a:');
+
+    expect(del).toHaveBeenCalledTimes(3);
+    expect(del).toHaveBeenNthCalledWith(1, 'a:1', 'a:2');
+    expect(del).toHaveBeenNthCalledWith(2, 'a:3');
+    expect(del).toHaveBeenNthCalledWith(3, 'a:4');
+  });
+
+  it('does not call del when the scan yields nothing', async () => {
+    scanStream.mockReturnValue(streamOf([[], []]));
+
+    await service.delByPattern('a:');
+
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('swallows scan errors instead of breaking the caller', async () => {
+    scanStream.mockImplementation(() => {
+      throw new Error('redis exploded');
+    });
+
+    await expect(service.delByPattern('a:')).resolves.toBeUndefined();
+  });
+});

--- a/src/cache/cache.service.ts
+++ b/src/cache/cache.service.ts
@@ -110,11 +110,23 @@ export class CacheService {
       return;
     }
     try {
-      const keys = await this.redis.keys(`${prefix}*`);
-      if (keys.length > 0) {
-        await this.redis.del(...keys);
+      // KEYS 会阻塞整个 Redis 实例遍历全库，改用 SCAN 游标分批扫描并分批删除。
+      // SCAN 可能重复返回同一个 key，因此用 del 的实际返回值统计，而不是扫到的数量。
+      const stream = this.redis.scanStream({
+        match: `${prefix}*`,
+        count: 100,
+      });
+      let deleted = 0;
+
+      for await (const keys of stream as AsyncIterable<string[]>) {
+        if (keys.length > 0) {
+          deleted += await this.redis.del(...keys);
+        }
+      }
+
+      if (deleted > 0) {
         this.logger.log(
-          `🗑️ [REDIS] Deleted ${keys.length} keys with prefix: ${prefix}`,
+          `🗑️ [REDIS] Deleted ${deleted} keys with prefix: ${prefix}`,
         );
       }
     } catch (error) {

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -31,9 +31,19 @@ export default (): ConfigType => ({
   BRIEF_MAX_TOPICS: parseInt(process.env.BRIEF_MAX_TOPICS) || 12,
   BRIEF_STOCK_RANKING_CACHE_TTL:
     parseInt(process.env.BRIEF_STOCK_RANKING_CACHE_TTL) || 43200,
+  BRIEF_GENERATING_TIMEOUT_MINUTES:
+    parseInt(process.env.BRIEF_GENERATING_TIMEOUT_MINUTES) || 30,
+  BRIEF_SOURCE_CONCURRENCY: parseInt(process.env.BRIEF_SOURCE_CONCURRENCY) || 3,
+  BRIEF_SEARCH_CONCURRENCY: parseInt(process.env.BRIEF_SEARCH_CONCURRENCY) || 3,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
   OPENAI_API_BASE_URL: process.env.OPENAI_API_BASE_URL || '',
   AI_MODEL: process.env.AI_MODEL || 'deepseek-v4-flash',
+  AI_TIMEOUT_MS: parseInt(process.env.AI_TIMEOUT_MS) || 120000,
+  // 0 是合法值（关闭重试），因此不能用 `|| 2` 兜底
+  AI_MAX_RETRIES: Number.isFinite(parseInt(process.env.AI_MAX_RETRIES))
+    ? parseInt(process.env.AI_MAX_RETRIES)
+    : 2,
   TAVILY_API_KEY: process.env.TAVILY_API_KEY || '',
   TAVILY_MAX_RESULTS: parseInt(process.env.TAVILY_MAX_RESULTS) || 5,
+  TAVILY_TIMEOUT_MS: parseInt(process.env.TAVILY_TIMEOUT_MS) || 10000,
 });

--- a/src/config/validation.schema.ts
+++ b/src/config/validation.schema.ts
@@ -41,12 +41,19 @@ export const configValidationSchema = z.object({
   BRIEF_LOOKBACK_HOURS: z.coerce.number().default(24),
   BRIEF_TOP_ITEMS_PER_SOURCE: z.coerce.number().default(10),
   BRIEF_MAX_TOPICS: z.coerce.number().default(12),
-  BRIEF_STOCK_RANKING_CACHE_TTL: z.coerce.number().default(43200),
+  // 下限 1：之前靠 service 里的 `ttl > 0 ? ttl : 默认值` 兜底，改为启动时直接拒绝非法值
+  BRIEF_STOCK_RANKING_CACHE_TTL: z.coerce.number().min(1).default(43200),
+  BRIEF_GENERATING_TIMEOUT_MINUTES: z.coerce.number().min(1).default(30),
+  BRIEF_SOURCE_CONCURRENCY: z.coerce.number().min(1).default(3),
+  BRIEF_SEARCH_CONCURRENCY: z.coerce.number().min(1).default(3),
   OPENAI_API_KEY: z.string().default(''),
   OPENAI_API_BASE_URL: z.string().default(''),
   AI_MODEL: z.string().default('deepseek-v4-flash'),
+  AI_TIMEOUT_MS: z.coerce.number().min(1000).default(120000),
+  AI_MAX_RETRIES: z.coerce.number().min(0).default(2),
   TAVILY_API_KEY: z.string().default(''),
   TAVILY_MAX_RESULTS: z.coerce.number().default(5),
+  TAVILY_TIMEOUT_MS: z.coerce.number().min(1000).default(10000),
 });
 
 export type ConfigType = z.infer<typeof configValidationSchema>;

--- a/src/daily-brief/clients/ai-analysis.client.spec.ts
+++ b/src/daily-brief/clients/ai-analysis.client.spec.ts
@@ -1,0 +1,51 @@
+import { AiAnalysisClient } from './ai-analysis.client';
+import { BriefAnalysis } from '../interfaces/daily-brief.interface';
+
+interface ParseAnalysisInternals {
+  parseAnalysis(content: string): BriefAnalysis;
+}
+
+describe('AiAnalysisClient parseAnalysis', () => {
+  const client = new AiAnalysisClient({} as never);
+  const parse = (content: string) =>
+    (client as unknown as ParseAnalysisInternals).parseAnalysis(content);
+
+  const validAnalysis = {
+    summary: '今日核心结论',
+    highlights: ['要点一'],
+    topics: [{ title: '主题一', event: '发生了什么' }],
+    risks: [],
+    followUpSignals: [],
+    markdown: '# 每日简报',
+  };
+
+  it('accepts a complete analysis and applies field defaults', () => {
+    const result = parse(JSON.stringify(validAnalysis));
+
+    expect(result.summary).toBe('今日核心结论');
+    expect(result.topics).toHaveLength(1);
+    // 未提供的字段由 schema 的 .catch() 兜底
+    expect(result.topics[0].impactDirection).toBe('待验证');
+    expect(result.topics[0].aShareMapping).toEqual([]);
+  });
+
+  it('rejects an empty object instead of producing a blank brief', () => {
+    expect(() => parse('{}')).toThrow(/without a summary/);
+  });
+
+  it('rejects an analysis with a summary but no topics', () => {
+    expect(() =>
+      parse(JSON.stringify({ ...validAnalysis, topics: [] })),
+    ).toThrow(/without any topic/);
+  });
+
+  it('rejects a whitespace-only summary', () => {
+    expect(() =>
+      parse(JSON.stringify({ ...validAnalysis, summary: '   ' })),
+    ).toThrow(/without a summary/);
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(() => parse('not json')).toThrow(/invalid JSON/);
+  });
+});

--- a/src/daily-brief/clients/ai-analysis.client.ts
+++ b/src/daily-brief/clients/ai-analysis.client.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
 import { z } from 'zod';
 import {
@@ -7,6 +6,7 @@ import {
   BriefInputItem,
   BriefSearchEvidence,
 } from '../interfaces/daily-brief.interface';
+import { DailyBriefConfigService } from '../daily-brief.config';
 
 const stringArraySchema = z.array(z.string()).catch([]);
 
@@ -62,7 +62,7 @@ const briefAnalysisSchema = z
 
 @Injectable()
 export class AiAnalysisClient {
-  constructor(private readonly configService: ConfigService) {}
+  constructor(private readonly config: DailyBriefConfigService) {}
 
   async analyzeDailyBrief(input: {
     briefDate: string;
@@ -70,7 +70,7 @@ export class AiAnalysisClient {
     items: BriefInputItem[];
     searchEvidence: BriefSearchEvidence[];
   }): Promise<BriefAnalysis> {
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
+    const apiKey = this.config.openaiApiKey;
     if (!apiKey) {
       throw new Error('OPENAI_API_KEY is not configured');
     }
@@ -78,7 +78,10 @@ export class AiAnalysisClient {
     const model = this.getModel();
     const client = new OpenAI({
       apiKey,
-      baseURL: this.configService.get<string>('OPENAI_API_BASE_URL'),
+      baseURL: this.config.openaiBaseUrl,
+      // SDK 默认是 10 分钟超时 + 2 次重试，最坏情况会把整次简报生成挂住半小时
+      timeout: this.config.aiTimeoutMs,
+      maxRetries: this.config.aiMaxRetries,
     });
 
     const completion = await client.chat.completions.create({
@@ -117,7 +120,7 @@ export class AiAnalysisClient {
   }
 
   getModel(): string {
-    return this.configService.get<string>('AI_MODEL', 'deepseek-v4-flash');
+    return this.config.aiModel;
   }
 
   private getJsonSchemaInstruction() {
@@ -179,6 +182,16 @@ export class AiAnalysisClient {
       );
     }
 
-    return result.data as BriefAnalysis;
+    // schema 里每个字段都带 .catch()，`{}` 之类的响应同样会解析成功。
+    // 没有这层校验，一份空简报会被当成生成成功写库。
+    const analysis = result.data as BriefAnalysis;
+    if (!analysis.summary.trim()) {
+      throw new Error('AI returned a brief analysis without a summary');
+    }
+    if (analysis.topics.length === 0) {
+      throw new Error('AI returned a brief analysis without any topic');
+    }
+
+    return analysis;
   }
 }

--- a/src/daily-brief/clients/tavily-search.client.ts
+++ b/src/daily-brief/clients/tavily-search.client.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { BriefSearchResult } from '../interfaces/daily-brief.interface';
+import { DailyBriefConfigService } from '../daily-brief.config';
 
 interface TavilyResponse {
   results?: Array<{
@@ -15,16 +15,17 @@ interface TavilyResponse {
 export class TavilySearchClient {
   private readonly logger = new Logger(TavilySearchClient.name);
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(private readonly config: DailyBriefConfigService) {}
 
   async search(query: string): Promise<BriefSearchResult[]> {
-    const apiKey = this.configService.get<string>('TAVILY_API_KEY');
+    const apiKey = this.config.tavilyApiKey;
     if (!apiKey) {
       this.logger.warn('TAVILY_API_KEY is not configured, skipping search');
       return [];
     }
 
-    const maxResults = this.configService.get<number>('TAVILY_MAX_RESULTS', 5);
+    const maxResults = this.config.tavilyMaxResults;
+    const timeoutMs = this.config.tavilyTimeoutMs;
 
     try {
       const response = await fetch('https://api.tavily.com/search', {
@@ -40,6 +41,7 @@ export class TavilySearchClient {
           include_raw_content: false,
           max_results: maxResults,
         }),
+        signal: AbortSignal.timeout(timeoutMs),
       });
 
       if (!response.ok) {
@@ -59,11 +61,13 @@ export class TavilySearchClient {
           score: item.score,
         }));
     } catch (error) {
-      this.logger.warn(
-        `Tavily search error: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
+      const reason =
+        error instanceof Error && error.name === 'TimeoutError'
+          ? `timed out after ${timeoutMs}ms`
+          : error instanceof Error
+            ? error.message
+            : String(error);
+      this.logger.warn(`Tavily search error: ${reason}`);
       return [];
     }
   }

--- a/src/daily-brief/daily-brief.config.spec.ts
+++ b/src/daily-brief/daily-brief.config.spec.ts
@@ -1,0 +1,78 @@
+import { DailyBriefConfigService } from './daily-brief.config';
+
+describe('DailyBriefConfigService', () => {
+  const values: Record<string, unknown> = {
+    BRIEF_ENABLED: false,
+    BRIEF_CRON_EXPRESSION: '0 12 * * *',
+    BRIEF_TIMEZONE: 'Asia/Shanghai',
+    BRIEF_SOURCES: 'cls, eastmoney ,,gelonghui',
+    BRIEF_LOOKBACK_HOURS: 24,
+    BRIEF_TOP_ITEMS_PER_SOURCE: 10,
+    BRIEF_MAX_TOPICS: 12,
+    BRIEF_STOCK_RANKING_CACHE_TTL: 43200,
+    BRIEF_GENERATING_TIMEOUT_MINUTES: 30,
+    BRIEF_SOURCE_CONCURRENCY: 3,
+    BRIEF_SEARCH_CONCURRENCY: 3,
+    AI_MODEL: 'deepseek-v4-flash',
+    AI_TIMEOUT_MS: 120000,
+    AI_MAX_RETRIES: 0,
+    OPENAI_API_KEY: 'sk-test',
+    OPENAI_API_BASE_URL: '',
+    TAVILY_API_KEY: '',
+    TAVILY_MAX_RESULTS: 5,
+    TAVILY_TIMEOUT_MS: 10000,
+  };
+
+  const getOrThrow = jest.fn((key: string) => {
+    if (!(key in values)) {
+      throw new TypeError(`Configuration key "${key}" does not exist`);
+    }
+    return values[key];
+  });
+  const config = new DailyBriefConfigService({ getOrThrow } as never);
+
+  it('exposes every daily brief setting', () => {
+    expect(config.enabled).toBe(false);
+    expect(config.cronExpression).toBe('0 12 * * *');
+    expect(config.timezone).toBe('Asia/Shanghai');
+    expect(config.lookbackHours).toBe(24);
+    expect(config.topItemsPerSource).toBe(10);
+    expect(config.maxTopics).toBe(12);
+    expect(config.stockRankingCacheTtl).toBe(43200);
+    expect(config.generatingTimeoutMinutes).toBe(30);
+    expect(config.sourceConcurrency).toBe(3);
+    expect(config.searchConcurrency).toBe(3);
+    expect(config.aiModel).toBe('deepseek-v4-flash');
+    expect(config.aiTimeoutMs).toBe(120000);
+    expect(config.tavilyMaxResults).toBe(5);
+    expect(config.tavilyTimeoutMs).toBe(10000);
+  });
+
+  it('trims and filters the source list', () => {
+    expect(config.sources).toEqual(['cls', 'eastmoney', 'gelonghui']);
+  });
+
+  it('keeps 0 for AI_MAX_RETRIES instead of falling back to a default', () => {
+    expect(config.aiMaxRetries).toBe(0);
+  });
+
+  it('normalises an empty OPENAI_API_BASE_URL to undefined', () => {
+    // OpenAI SDK 用 `??` 兜底 baseURL，空字符串会让它拼出错误的地址
+    expect(config.openaiBaseUrl).toBeUndefined();
+
+    values.OPENAI_API_BASE_URL = 'https://api.deepseek.com';
+    expect(config.openaiBaseUrl).toBe('https://api.deepseek.com');
+  });
+
+  it('reports whether Tavily is configured', () => {
+    expect(config.tavilyConfigured).toBe(false);
+
+    values.TAVILY_API_KEY = 'tvly-test';
+    expect(config.tavilyConfigured).toBe(true);
+  });
+
+  it('throws when a key is missing from configuration.ts', () => {
+    delete values.BRIEF_TIMEZONE;
+    expect(() => config.timezone).toThrow(/does not exist/);
+  });
+});

--- a/src/daily-brief/daily-brief.config.ts
+++ b/src/daily-brief/daily-brief.config.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * 每日简报模块读取配置的统一入口。
+ *
+ * 默认值只存在于 `src/config/configuration.ts` 和 `src/config/validation.schema.ts`，
+ * 这里一律用 `getOrThrow` 取值，不再在调用点重复写一遍默认值——
+ * 之前同一个默认值散落在 service / scheduler / clients 里，改一处漏一处。
+ *
+ * `getOrThrow` 只在值为 `undefined` 时抛错，`false` 和 `0` 都能正常返回。
+ */
+@Injectable()
+export class DailyBriefConfigService {
+  constructor(private readonly configService: ConfigService) {}
+
+  get enabled(): boolean {
+    return this.configService.getOrThrow<boolean>('BRIEF_ENABLED');
+  }
+
+  get cronExpression(): string {
+    return this.configService.getOrThrow<string>('BRIEF_CRON_EXPRESSION');
+  }
+
+  get timezone(): string {
+    return this.configService.getOrThrow<string>('BRIEF_TIMEZONE');
+  }
+
+  /** 逗号分隔的源名称，已去空白并过滤空项。 */
+  get sources(): string[] {
+    return this.configService
+      .getOrThrow<string>('BRIEF_SOURCES')
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  get lookbackHours(): number {
+    return this.configService.getOrThrow<number>('BRIEF_LOOKBACK_HOURS');
+  }
+
+  get topItemsPerSource(): number {
+    return this.configService.getOrThrow<number>('BRIEF_TOP_ITEMS_PER_SOURCE');
+  }
+
+  get maxTopics(): number {
+    return this.configService.getOrThrow<number>('BRIEF_MAX_TOPICS');
+  }
+
+  get stockRankingCacheTtl(): number {
+    return this.configService.getOrThrow<number>(
+      'BRIEF_STOCK_RANKING_CACHE_TTL',
+    );
+  }
+
+  get generatingTimeoutMinutes(): number {
+    return this.configService.getOrThrow<number>(
+      'BRIEF_GENERATING_TIMEOUT_MINUTES',
+    );
+  }
+
+  get sourceConcurrency(): number {
+    return this.configService.getOrThrow<number>('BRIEF_SOURCE_CONCURRENCY');
+  }
+
+  get searchConcurrency(): number {
+    return this.configService.getOrThrow<number>('BRIEF_SEARCH_CONCURRENCY');
+  }
+
+  get aiModel(): string {
+    return this.configService.getOrThrow<string>('AI_MODEL');
+  }
+
+  get aiTimeoutMs(): number {
+    return this.configService.getOrThrow<number>('AI_TIMEOUT_MS');
+  }
+
+  get aiMaxRetries(): number {
+    return this.configService.getOrThrow<number>('AI_MAX_RETRIES');
+  }
+
+  get openaiApiKey(): string {
+    return this.configService.getOrThrow<string>('OPENAI_API_KEY');
+  }
+
+  /**
+   * 未配置时返回 undefined 而不是空字符串：
+   * OpenAI SDK 用 `??` 兜底 baseURL，传空字符串会让它拼出错误的地址。
+   */
+  get openaiBaseUrl(): string | undefined {
+    return (
+      this.configService.getOrThrow<string>('OPENAI_API_BASE_URL') || undefined
+    );
+  }
+
+  get tavilyApiKey(): string {
+    return this.configService.getOrThrow<string>('TAVILY_API_KEY');
+  }
+
+  get tavilyConfigured(): boolean {
+    return Boolean(this.tavilyApiKey);
+  }
+
+  get tavilyMaxResults(): number {
+    return this.configService.getOrThrow<number>('TAVILY_MAX_RESULTS');
+  }
+
+  get tavilyTimeoutMs(): number {
+    return this.configService.getOrThrow<number>('TAVILY_TIMEOUT_MS');
+  }
+}

--- a/src/daily-brief/daily-brief.controller.ts
+++ b/src/daily-brief/daily-brief.controller.ts
@@ -4,7 +4,6 @@ import {
   Delete,
   Get,
   Param,
-  ParseIntPipe,
   Post,
   Query,
 } from '@nestjs/common';
@@ -12,6 +11,8 @@ import { DailyBriefService } from './daily-brief.service';
 import { DailyBriefScheduler } from './daily-brief.scheduler';
 import { GenerateBriefDto } from './dto/generate-brief.dto';
 import { StockRankingQueryDto } from './dto/stock-ranking-query.dto';
+import { ListBriefsQueryDto } from './dto/list-briefs-query.dto';
+import { BriefDateParamDto } from './dto/brief-date-param.dto';
 
 @Controller('api/briefs')
 export class DailyBriefController {
@@ -27,7 +28,10 @@ export class DailyBriefController {
 
   @Get('config')
   getConfig() {
-    return this.dailyBriefService.getConfig();
+    return {
+      enabled: this.dailyBriefScheduler.isEnabled(),
+      ...this.dailyBriefService.getConfig(),
+    };
   }
 
   @Get('scheduler/status')
@@ -65,20 +69,8 @@ export class DailyBriefController {
   }
 
   @Get()
-  list(
-    @Query('page', new ParseIntPipe({ optional: true })) page?: number,
-    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
-    @Query('status') status?: 'generating' | 'success' | 'failed',
-    @Query('period') period?: string,
-    @Query('includeDebug') includeDebug?: string,
-  ) {
-    return this.dailyBriefService.list({
-      page,
-      limit,
-      status,
-      period,
-      includeDebug: this.parseBoolean(includeDebug),
-    });
+  list(@Query() query: ListBriefsQueryDto) {
+    return this.dailyBriefService.list(query);
   }
 
   @Get('statistics/stocks')
@@ -101,20 +93,23 @@ export class DailyBriefController {
 
   @Get(':date')
   findByDate(
-    @Param('date') date: string,
+    @Param() params: BriefDateParamDto,
     @Query('period') period?: string,
     @Query('includeDebug') includeDebug?: string,
   ) {
     return this.dailyBriefService.findByDate(
-      date,
+      params.date,
       period,
       this.parseBoolean(includeDebug),
     );
   }
 
   @Delete(':date')
-  deleteByDate(@Param('date') date: string, @Query('period') period?: string) {
-    return this.dailyBriefService.deleteByDate(date, period);
+  deleteByDate(
+    @Param() params: BriefDateParamDto,
+    @Query('period') period?: string,
+  ) {
+    return this.dailyBriefService.deleteByDate(params.date, period);
   }
 
   private parseBoolean(value?: string) {

--- a/src/daily-brief/daily-brief.module.ts
+++ b/src/daily-brief/daily-brief.module.ts
@@ -8,11 +8,13 @@ import { TavilySearchClient } from './clients/tavily-search.client';
 import { DailyBriefController } from './daily-brief.controller';
 import { DailyBriefScheduler } from './daily-brief.scheduler';
 import { DailyBriefService } from './daily-brief.service';
+import { DailyBriefConfigService } from './daily-brief.config';
 
 @Module({
   imports: [ScheduleModule, CacheModule, DatabaseModule, HotListsModule],
   controllers: [DailyBriefController],
   providers: [
+    DailyBriefConfigService,
     DailyBriefService,
     DailyBriefScheduler,
     AiAnalysisClient,

--- a/src/daily-brief/daily-brief.scheduler.ts
+++ b/src/daily-brief/daily-brief.scheduler.ts
@@ -4,10 +4,10 @@ import {
   OnModuleDestroy,
   OnModuleInit,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { CronJob } from 'cron';
 import { DailyBriefService } from './daily-brief.service';
+import { DailyBriefConfigService } from './daily-brief.config';
 
 @Injectable()
 export class DailyBriefScheduler implements OnModuleInit, OnModuleDestroy {
@@ -17,11 +17,11 @@ export class DailyBriefScheduler implements OnModuleInit, OnModuleDestroy {
   private enabled = false;
 
   constructor(
-    private readonly configService: ConfigService,
+    private readonly config: DailyBriefConfigService,
     private readonly schedulerRegistry: SchedulerRegistry,
     private readonly dailyBriefService: DailyBriefService,
   ) {
-    this.enabled = this.configService.get<boolean>('BRIEF_ENABLED', false);
+    this.enabled = this.config.enabled;
   }
 
   onModuleInit() {
@@ -32,18 +32,20 @@ export class DailyBriefScheduler implements OnModuleInit, OnModuleDestroy {
     this.stopCronJob();
   }
 
+  /**
+   * 调度器是否启用的唯一事实来源。
+   * `start()` / `stop()` 只改内存状态，直接读 `BRIEF_ENABLED` 会与真实状态不一致。
+   */
+  isEnabled() {
+    return this.enabled;
+  }
+
   getStatus() {
     return {
       isRunning: this.isRunning,
       enabled: this.enabled,
-      cronExpression: this.configService.get<string>(
-        'BRIEF_CRON_EXPRESSION',
-        '0 12 * * *',
-      ),
-      timezone: this.configService.get<string>(
-        'BRIEF_TIMEZONE',
-        'Asia/Shanghai',
-      ),
+      cronExpression: this.config.cronExpression,
+      timezone: this.config.timezone,
       cronJobExists: this.schedulerRegistry.doesExist('cron', this.cronJobName),
     };
   }
@@ -59,6 +61,8 @@ export class DailyBriefScheduler implements OnModuleInit, OnModuleDestroy {
   }
 
   reconfigure() {
+    // 重新读取配置，使其与 cron 表达式、时区一样跟随配置变化
+    this.enabled = this.config.enabled;
     this.setupCronJob();
   }
 
@@ -71,14 +75,8 @@ export class DailyBriefScheduler implements OnModuleInit, OnModuleDestroy {
         return;
       }
 
-      const cronExpression = this.configService.get<string>(
-        'BRIEF_CRON_EXPRESSION',
-        '0 12 * * *',
-      );
-      const timezone = this.configService.get<string>(
-        'BRIEF_TIMEZONE',
-        'Asia/Shanghai',
-      );
+      const cronExpression = this.config.cronExpression;
+      const timezone = this.config.timezone;
       const job = new CronJob(
         cronExpression,
         () => {

--- a/src/daily-brief/daily-brief.service.spec.ts
+++ b/src/daily-brief/daily-brief.service.spec.ts
@@ -6,7 +6,6 @@ describe('DailyBriefService stock ranking', () => {
   const cacheGet = jest.fn();
   const cacheSet = jest.fn();
   const cacheDelByPattern = jest.fn();
-  const configGet = jest.fn();
   let service: DailyBriefService;
 
   beforeEach(() => {
@@ -14,13 +13,8 @@ describe('DailyBriefService stock ranking', () => {
     cacheGet.mockReset().mockResolvedValue(null);
     cacheSet.mockReset().mockResolvedValue(undefined);
     cacheDelByPattern.mockReset().mockResolvedValue(undefined);
-    configGet
-      .mockReset()
-      .mockImplementation(
-        (_key: string, defaultValue: unknown) => defaultValue,
-      );
     service = new DailyBriefService(
-      { get: configGet } as never,
+      { stockRankingCacheTtl: 43200 } as never,
       { getStockRanking } as never,
       undefined,
       undefined,
@@ -119,5 +113,153 @@ describe('DailyBriefService stock ranking', () => {
       }),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(getStockRanking).not.toHaveBeenCalled();
+  });
+});
+
+describe('DailyBriefService generateBrief', () => {
+  const findByDate = jest.fn();
+  const upsertGenerating = jest.fn();
+  const markSuccess = jest.fn();
+  const markFailed = jest.fn();
+  const saveHotItems = jest.fn();
+  const getDataByTimeRange = jest.fn();
+  const getHotList = jest.fn();
+  const analyzeDailyBrief = jest.fn();
+  const search = jest.fn();
+  const cacheDelByPattern = jest.fn();
+  let config: Record<string, unknown>;
+  let service: DailyBriefService;
+
+  const buildItems = (prefix: string, count: number) =>
+    Array.from({ length: count }, (_, index) => ({
+      title: `${prefix}-标题-${index}`,
+      desc: `${prefix}-描述-${index}`,
+      hot: 100 - index,
+      url: `https://example.com/${prefix}/${index}`,
+      mobileUrl: `https://m.example.com/${prefix}/${index}`,
+      timestamp: 1700000000000 - index * 1000,
+    }));
+
+  beforeEach(() => {
+    config = {
+      timezone: 'Asia/Shanghai',
+      // 配置里默认有 3 个源，用来验证条目上限按请求的源数而不是配置算
+      sources: ['cls', 'eastmoney', 'gelonghui'],
+      lookbackHours: 24,
+      topItemsPerSource: 2,
+      maxTopics: 12,
+      sourceConcurrency: 3,
+      searchConcurrency: 3,
+      generatingTimeoutMinutes: 30,
+    };
+    findByDate.mockReset().mockResolvedValue(null);
+    upsertGenerating.mockReset().mockResolvedValue(undefined);
+    markSuccess
+      .mockReset()
+      .mockImplementation((briefDate: string) =>
+        Promise.resolve({ briefDate, status: 'success' }),
+      );
+    markFailed.mockReset().mockResolvedValue(undefined);
+    saveHotItems.mockReset().mockResolvedValue(0);
+    getDataByTimeRange.mockReset().mockResolvedValue([]);
+    getHotList.mockReset().mockResolvedValue({ data: [] });
+    analyzeDailyBrief.mockReset().mockResolvedValue({
+      summary: '结论',
+      highlights: [],
+      topics: [],
+      risks: [],
+      followUpSignals: [],
+      markdown: '# 每日简报',
+    });
+    search.mockReset().mockResolvedValue([]);
+    cacheDelByPattern.mockReset().mockResolvedValue(undefined);
+
+    service = new DailyBriefService(
+      config as never,
+      { findByDate, upsertGenerating, markSuccess, markFailed } as never,
+      { saveHotItems, getDataByTimeRange } as never,
+      { getHotList } as never,
+      { getModel: () => 'test-model', analyzeDailyBrief } as never,
+      { search } as never,
+      { delByPattern: cacheDelByPattern } as never,
+    );
+  });
+
+  it('caps input items by the requested source count, not the configured one', async () => {
+    // 配置里默认有 3 个源，这里只请求 1 个：上限应为 1 * 2 = 2
+    getHotList.mockResolvedValue({ data: buildItems('fetched', 5) });
+    getDataByTimeRange.mockResolvedValue(buildItems('history', 5));
+
+    await service.generateBrief({ sources: ['cls'], force: true });
+
+    expect(analyzeDailyBrief).toHaveBeenCalledTimes(1);
+    const { items, sources } = analyzeDailyBrief.mock.calls[0][0] as {
+      items: unknown[];
+      sources: string[];
+    };
+    expect(sources).toEqual(['cls']);
+    expect(items).toHaveLength(2);
+  });
+
+  it('rejects a concurrent request while a fresh generation is in flight', async () => {
+    findByDate.mockResolvedValue({
+      status: 'generating',
+      updatedAt: new Date(),
+    });
+
+    await expect(service.generateBrief({})).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    expect(upsertGenerating).not.toHaveBeenCalled();
+  });
+
+  it('regenerates when a generating brief is older than the staleness timeout', async () => {
+    findByDate.mockResolvedValue({
+      status: 'generating',
+      updatedAt: new Date(Date.now() - 31 * 60000),
+    });
+    getHotList.mockResolvedValue({ data: buildItems('fetched', 2) });
+
+    await expect(service.generateBrief({})).resolves.toEqual({
+      briefDate: expect.any(String),
+      status: 'success',
+    });
+    expect(upsertGenerating).toHaveBeenCalledTimes(1);
+    expect(analyzeDailyBrief).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a generating brief with no updatedAt as stale', async () => {
+    findByDate.mockResolvedValue({ status: 'generating' });
+    getHotList.mockResolvedValue({ data: buildItems('fetched', 2) });
+
+    await service.generateBrief({});
+
+    expect(analyzeDailyBrief).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours a custom staleness timeout', async () => {
+    config.generatingTimeoutMinutes = 120;
+    findByDate.mockResolvedValue({
+      status: 'generating',
+      updatedAt: new Date(Date.now() - 31 * 60000),
+    });
+
+    await expect(service.generateBrief({})).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('marks the brief failed when analysis throws', async () => {
+    getHotList.mockResolvedValue({ data: buildItems('fetched', 2) });
+    analyzeDailyBrief.mockRejectedValue(new Error('AI exploded'));
+
+    await expect(service.generateBrief({ force: true })).rejects.toThrow(
+      'AI exploded',
+    );
+    expect(markFailed).toHaveBeenCalledWith(
+      expect.any(String),
+      'daily',
+      'AI exploded',
+    );
   });
 });

--- a/src/daily-brief/daily-brief.service.ts
+++ b/src/daily-brief/daily-brief.service.ts
@@ -1,5 +1,4 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { CacheData, CacheService } from '../cache/cache.service';
 import {
   DailyBriefRepository,
@@ -15,9 +14,11 @@ import {
   GenerateBriefOptions,
 } from './interfaces/daily-brief.interface';
 import { StockRankingQueryDto } from './dto/stock-ranking-query.dto';
+import { mapWithConcurrency } from './utils/concurrency';
+import { endOfBriefDate, formatBriefDate } from './utils/brief-date';
+import { DailyBriefConfigService } from './daily-brief.config';
 
 const STOCK_RANKING_CACHE_PREFIX = 'daily-brief:statistics:stocks:';
-const DEFAULT_STOCK_RANKING_CACHE_TTL = 12 * 60 * 60;
 
 export interface StockRankingResponse {
   filters: {
@@ -39,7 +40,7 @@ export class DailyBriefService {
   private readonly logger = new Logger(DailyBriefService.name);
 
   constructor(
-    private readonly configService: ConfigService,
+    private readonly config: DailyBriefConfigService,
     private readonly dailyBriefRepository: DailyBriefRepository,
     private readonly hotItemRepository: HotItemRepository,
     private readonly hotListsService: HotListsService,
@@ -52,11 +53,10 @@ export class DailyBriefService {
     const period = options.period || 'daily';
     const briefDate = options.date || this.formatDate(new Date());
     const sources = this.resolveSources(options.sources);
-    const lookbackHours = this.configService.get<number>(
-      'BRIEF_LOOKBACK_HOURS',
-      24,
+    const inputWindow = this.resolveInputWindow(
+      briefDate,
+      this.config.lookbackHours,
     );
-    const inputWindow = this.resolveInputWindow(briefDate, lookbackHours);
 
     if (!options.force) {
       const existing = await this.dailyBriefRepository.findByDate(
@@ -68,12 +68,19 @@ export class DailyBriefService {
           return existing;
         }
         if (existing.status === 'generating') {
-          throw new BadRequestException(
-            'A daily brief is already being generated for date ' +
-              briefDate +
-              ' and period ' +
-              period +
-              '.',
+          // 进程在生成过程中被中断时文档会永远停在 generating，
+          // 超过阈值就当作失败处理，否则该日期会被永久锁死。
+          if (!this.isGenerationStale(existing.updatedAt)) {
+            throw new BadRequestException(
+              'A daily brief is already being generated for date ' +
+                briefDate +
+                ' and period ' +
+                period +
+                '.',
+            );
+          }
+          this.logger.warn(
+            `Found a stale generating brief for ${briefDate}/${period}, regenerating`,
           );
         }
       }
@@ -94,10 +101,10 @@ export class DailyBriefService {
         inputWindow.start.getTime(),
         inputWindow.end.getTime(),
       );
-      const inputItems = this.mergeAndLimitItems([
-        ...fetchedItems,
-        ...historyItems,
-      ]);
+      const inputItems = this.mergeAndLimitItems(
+        [...fetchedItems, ...historyItems],
+        sources.length,
+      );
 
       if (inputItems.length === 0) {
         throw new Error('No hot items available for brief generation');
@@ -131,8 +138,8 @@ export class DailyBriefService {
       return this.toPublicBrief(brief);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      // 失败时没有任何简报内容落库，排名数据不变，无需清缓存
       await this.dailyBriefRepository.markFailed(briefDate, period, message);
-      await this.invalidateStockRankingCache();
       throw error;
     }
   }
@@ -145,12 +152,15 @@ export class DailyBriefService {
     return this.dailyBriefRepository.findByDate(date, period, includeDebug);
   }
 
+  /**
+   * 列表只返回摘要字段，因此没有 `includeDebug`：
+   * 需要 rawInputItems / searchEvidence 时用 findLatest 或 findByDate。
+   */
   list(options: {
     page?: number;
     limit?: number;
     status?: 'generating' | 'success' | 'failed';
     period?: string;
-    includeDebug?: boolean;
   }) {
     return this.dailyBriefRepository.list(options);
   }
@@ -197,16 +207,10 @@ export class DailyBriefService {
         ...item,
       })),
     };
-    const configuredTtl = this.configService.get<number>(
-      'BRIEF_STOCK_RANKING_CACHE_TTL',
-      DEFAULT_STOCK_RANKING_CACHE_TTL,
-    );
-    const ttl =
-      configuredTtl > 0 ? configuredTtl : DEFAULT_STOCK_RANKING_CACHE_TTL;
     await this.cacheService.set(
       cacheKey,
       { data: response, updateTime: new Date().toISOString() },
-      ttl,
+      this.config.stockRankingCacheTtl,
     );
 
     return response;
@@ -259,32 +263,21 @@ export class DailyBriefService {
     };
   }
 
+  /**
+   * 不包含 `enabled`：调度器可以在运行期被 start/stop，
+   * 真实状态由 `DailyBriefScheduler.isEnabled()` 提供，在 controller 里合并。
+   */
   getConfig() {
     return {
-      enabled: this.configService.get<boolean>('BRIEF_ENABLED', false),
-      cronExpression: this.configService.get<string>(
-        'BRIEF_CRON_EXPRESSION',
-        '0 12 * * *',
-      ),
-      timezone: this.configService.get<string>(
-        'BRIEF_TIMEZONE',
-        'Asia/Shanghai',
-      ),
+      cronExpression: this.config.cronExpression,
+      timezone: this.config.timezone,
       sources: this.resolveSources(),
-      lookbackHours: this.configService.get<number>('BRIEF_LOOKBACK_HOURS', 24),
-      topItemsPerSource: this.configService.get<number>(
-        'BRIEF_TOP_ITEMS_PER_SOURCE',
-        10,
-      ),
-      maxTopics: this.configService.get<number>('BRIEF_MAX_TOPICS', 12),
-      stockRankingCacheTtl: this.configService.get<number>(
-        'BRIEF_STOCK_RANKING_CACHE_TTL',
-        DEFAULT_STOCK_RANKING_CACHE_TTL,
-      ),
+      lookbackHours: this.config.lookbackHours,
+      topItemsPerSource: this.config.topItemsPerSource,
+      maxTopics: this.config.maxTopics,
+      stockRankingCacheTtl: this.config.stockRankingCacheTtl,
       model: this.aiAnalysisClient.getModel(),
-      tavilyConfigured: Boolean(
-        this.configService.get<string>('TAVILY_API_KEY'),
-      ),
+      tavilyConfigured: this.config.tavilyConfigured,
     };
   }
 
@@ -307,23 +300,25 @@ export class DailyBriefService {
   private async fetchLatestSourceItems(
     sources: string[],
   ): Promise<BriefInputItem[]> {
-    const topItemsPerSource = this.configService.get<number>(
-      'BRIEF_TOP_ITEMS_PER_SOURCE',
-      10,
-    );
-    const results: BriefInputItem[] = [];
+    const topItemsPerSource = this.config.topItemsPerSource;
 
-    for (const source of sources) {
-      try {
-        const hotList = await this.hotListsService.getHotList(source, {}, true);
-        if (!hotList.data.length) {
-          continue;
-        }
+    const results = await mapWithConcurrency(
+      sources,
+      this.config.sourceConcurrency,
+      async (source): Promise<BriefInputItem[]> => {
+        try {
+          const hotList = await this.hotListsService.getHotList(
+            source,
+            {},
+            true,
+          );
+          if (!hotList.data.length) {
+            return [];
+          }
 
-        await this.hotItemRepository.saveHotItems(hotList.data, source);
+          await this.hotItemRepository.saveHotItems(hotList.data, source);
 
-        results.push(
-          ...hotList.data.slice(0, topItemsPerSource).map((item) => ({
+          return hotList.data.slice(0, topItemsPerSource).map((item) => ({
             source,
             title: item.title,
             desc: item.desc,
@@ -331,18 +326,19 @@ export class DailyBriefService {
             url: item.url,
             mobileUrl: item.mobileUrl,
             timestamp: item.timestamp,
-          })),
-        );
-      } catch (error) {
-        this.logger.warn(
-          `Failed to refresh source ${source}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
-    }
+          }));
+        } catch (error) {
+          this.logger.warn(
+            `Failed to refresh source ${source}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          return [];
+        }
+      },
+    );
 
-    return results;
+    return results.flat();
   }
 
   private async loadHistoryItems(
@@ -350,10 +346,7 @@ export class DailyBriefService {
     startTime: number,
     endTime: number,
   ): Promise<BriefInputItem[]> {
-    const topItemsPerSource = this.configService.get<number>(
-      'BRIEF_TOP_ITEMS_PER_SOURCE',
-      10,
-    );
+    const topItemsPerSource = this.config.topItemsPerSource;
     const results = await Promise.all(
       sources.map(async (source) => {
         const items = await this.hotItemRepository.getDataByTimeRange(
@@ -381,10 +374,8 @@ export class DailyBriefService {
     return results.flat();
   }
 
-  private mergeAndLimitItems(items: BriefInputItem[]) {
-    const maxItems =
-      this.resolveSources().length *
-      this.configService.get<number>('BRIEF_TOP_ITEMS_PER_SOURCE', 10);
+  private mergeAndLimitItems(items: BriefInputItem[], sourceCount: number) {
+    const maxItems = Math.max(1, sourceCount) * this.config.topItemsPerSource;
     const seen = new Set<string>();
     const merged: BriefInputItem[] = [];
 
@@ -412,11 +403,12 @@ export class DailyBriefService {
   private async buildSearchEvidence(
     items: BriefInputItem[],
   ): Promise<BriefSearchEvidence[]> {
-    const maxTopics = this.configService.get<number>('BRIEF_MAX_TOPICS', 12);
-    const candidates = items.slice(0, maxTopics);
+    const candidates = items.slice(0, this.config.maxTopics);
 
-    return Promise.all(
-      candidates.map(async (item) => {
+    return mapWithConcurrency(
+      candidates,
+      this.config.searchConcurrency,
+      async (item) => {
         const query = `${item.title} ${item.desc || ''} 产业链 A股 影响`;
         const results = await this.tavilySearchClient.search(query);
         return {
@@ -424,29 +416,26 @@ export class DailyBriefService {
           query,
           results,
         };
-      }),
+      },
+    );
+  }
+
+  private isGenerationStale(updatedAt?: Date) {
+    if (!updatedAt) {
+      return true;
+    }
+
+    return (
+      Date.now() - new Date(updatedAt).getTime() >
+      this.config.generatingTimeoutMinutes * 60000
     );
   }
 
   private resolveSources(sources?: string[]) {
     const configuredSources =
-      sources && sources.length > 0
-        ? sources
-        : this.parseCsv(
-            this.configService.get<string>(
-              'BRIEF_SOURCES',
-              'cls,eastmoney,gelonghui',
-            ),
-          );
+      sources && sources.length > 0 ? sources : this.config.sources;
 
     return configuredSources.filter(Boolean);
-  }
-
-  private parseCsv(value: string) {
-    return value
-      .split(',')
-      .map((item) => item.trim())
-      .filter(Boolean);
   }
 
   private resolveInputWindow(briefDate: string, lookbackHours: number) {
@@ -455,7 +444,7 @@ export class DailyBriefService {
     const end =
       briefDate === today
         ? now
-        : this.createDateInTimezone(briefDate, 23, 59, 59);
+        : endOfBriefDate(briefDate, this.config.timezone);
     const start = new Date(end.getTime() - lookbackHours * 60 * 60 * 1000);
 
     return {
@@ -466,16 +455,7 @@ export class DailyBriefService {
   }
 
   private formatDate(date: Date) {
-    const timezone = this.configService.get<string>(
-      'BRIEF_TIMEZONE',
-      'Asia/Shanghai',
-    );
-    return new Intl.DateTimeFormat('en-CA', {
-      timeZone: timezone,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    }).format(date);
+    return formatBriefDate(date, this.config.timezone);
   }
 
   private validateBriefDate(date: string) {
@@ -522,54 +502,6 @@ export class DailyBriefService {
     }
 
     return this.formatDate(cutoff);
-  }
-
-  private createDateInTimezone(
-    date: string,
-    hour: number,
-    minute: number,
-    second: number,
-  ) {
-    const timezone = this.configService.get<string>(
-      'BRIEF_TIMEZONE',
-      'Asia/Shanghai',
-    );
-    const [year, month, day] = date.split('-').map(Number);
-    const utcGuess = new Date(
-      Date.UTC(year, month - 1, day, hour, minute, second),
-    );
-    const offset = this.getTimezoneOffset(utcGuess, timezone);
-
-    return new Date(utcGuess.getTime() - offset);
-  }
-
-  private getTimezoneOffset(date: Date, timezone: string) {
-    const parts = new Intl.DateTimeFormat('en-US', {
-      timeZone: timezone,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      hourCycle: 'h23',
-    }).formatToParts(date);
-    const values = Object.fromEntries(
-      parts
-        .filter((part) => part.type !== 'literal')
-        .map((part) => [part.type, Number(part.value)]),
-    );
-
-    return (
-      Date.UTC(
-        values.year,
-        values.month - 1,
-        values.day,
-        values.hour,
-        values.minute,
-        values.second,
-      ) - date.getTime()
-    );
   }
 
   private buildFallbackMarkdown(analysis: { summary: string }) {

--- a/src/daily-brief/dto/brief-date-param.dto.ts
+++ b/src/daily-brief/dto/brief-date-param.dto.ts
@@ -1,0 +1,8 @@
+import { Matches } from 'class-validator';
+
+export class BriefDateParamDto {
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'date must be in YYYY-MM-DD format',
+  })
+  date: string;
+}

--- a/src/daily-brief/dto/list-briefs-query.dto.ts
+++ b/src/daily-brief/dto/list-briefs-query.dto.ts
@@ -1,0 +1,24 @@
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class ListBriefsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+
+  @IsOptional()
+  @IsIn(['generating', 'success', 'failed'])
+  status?: 'generating' | 'success' | 'failed';
+
+  @IsOptional()
+  @IsString()
+  period?: string;
+}

--- a/src/daily-brief/utils/brief-date.spec.ts
+++ b/src/daily-brief/utils/brief-date.spec.ts
@@ -1,0 +1,111 @@
+import { endOfBriefDate, formatBriefDate } from './brief-date';
+
+/**
+ * 这两个函数替换掉了原来手写的 Intl 时区偏移计算。
+ * 下面把原实现原样保留为参照，逐一比对，确保行为没有变化——
+ * 包括夏令时切换这种手写实现最容易出错的场景。
+ */
+const legacyFormatDate = (date: Date, timezone: string) =>
+  new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+
+const legacyTimezoneOffset = (date: Date, timezone: string) => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(date);
+  const values = Object.fromEntries(
+    parts
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, Number(part.value)]),
+  );
+
+  return (
+    Date.UTC(
+      values.year,
+      values.month - 1,
+      values.day,
+      values.hour,
+      values.minute,
+      values.second,
+    ) - date.getTime()
+  );
+};
+
+const legacyCreateDateInTimezone = (date: string, timezone: string) => {
+  const [year, month, day] = date.split('-').map(Number);
+  const utcGuess = new Date(Date.UTC(year, month - 1, day, 23, 59, 59));
+  const offset = legacyTimezoneOffset(utcGuess, timezone);
+
+  return new Date(utcGuess.getTime() - offset);
+};
+
+const TIMEZONES = ['Asia/Shanghai', 'UTC', 'America/New_York', 'Europe/London'];
+
+const DATES = [
+  '2026-01-01',
+  '2026-03-08', // 美国夏令时开始当天
+  '2026-03-09',
+  '2026-06-15',
+  '2026-10-25', // 欧洲夏令时结束当天
+  '2026-11-01', // 美国夏令时结束当天
+  '2026-12-31',
+];
+
+describe('formatBriefDate', () => {
+  it.each(TIMEZONES)('matches the previous implementation in %s', (tz) => {
+    const samples = [
+      new Date('2026-01-01T00:00:00Z'),
+      new Date('2026-01-01T15:30:00Z'),
+      new Date('2026-06-15T23:59:59Z'),
+      new Date('2026-11-01T05:30:00Z'),
+      new Date('2026-12-31T16:00:00Z'),
+    ];
+
+    samples.forEach((sample) => {
+      expect(formatBriefDate(sample, tz)).toBe(legacyFormatDate(sample, tz));
+    });
+  });
+
+  it('rolls over to the next day for late UTC times in Asia/Shanghai', () => {
+    // UTC 16:00 已经是上海的次日 00:00
+    expect(
+      formatBriefDate(new Date('2026-06-15T16:00:00Z'), 'Asia/Shanghai'),
+    ).toBe('2026-06-16');
+  });
+});
+
+describe('endOfBriefDate', () => {
+  it.each(TIMEZONES)('matches the previous implementation in %s', (tz) => {
+    DATES.forEach((date) => {
+      expect(endOfBriefDate(date, tz).toISOString()).toBe(
+        legacyCreateDateInTimezone(date, tz).toISOString(),
+      );
+    });
+  });
+
+  it('returns the last second of the day in the target timezone', () => {
+    // 上海 UTC+8：当天 23:59:59 对应 UTC 15:59:59
+    expect(endOfBriefDate('2026-06-15', 'Asia/Shanghai').toISOString()).toBe(
+      '2026-06-15T15:59:59.000Z',
+    );
+  });
+
+  it('round-trips with formatBriefDate', () => {
+    TIMEZONES.forEach((tz) => {
+      DATES.forEach((date) => {
+        expect(formatBriefDate(endOfBriefDate(date, tz), tz)).toBe(date);
+      });
+    });
+  });
+});

--- a/src/daily-brief/utils/brief-date.ts
+++ b/src/daily-brief/utils/brief-date.ts
@@ -1,0 +1,14 @@
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+/** 取某个时刻在指定时区下的日期，格式 YYYY-MM-DD。 */
+export const formatBriefDate = (date: Date, tz: string): string =>
+  dayjs(date).tz(tz).format('YYYY-MM-DD');
+
+/** 取某个简报日期在指定时区下的当天最后一秒。 */
+export const endOfBriefDate = (briefDate: string, tz: string): Date =>
+  dayjs.tz(`${briefDate} 23:59:59`, tz).toDate();

--- a/src/daily-brief/utils/concurrency.spec.ts
+++ b/src/daily-brief/utils/concurrency.spec.ts
@@ -1,0 +1,34 @@
+import { mapWithConcurrency } from './concurrency';
+
+describe('mapWithConcurrency', () => {
+  it('preserves input order regardless of completion order', async () => {
+    const delays = [30, 0, 20, 10];
+    const result = await mapWithConcurrency(delays, 2, async (delay, index) => {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return index;
+    });
+
+    expect(result).toEqual([0, 1, 2, 3]);
+  });
+
+  it('never exceeds the configured concurrency', async () => {
+    let inFlight = 0;
+    let peak = 0;
+
+    await mapWithConcurrency([1, 2, 3, 4, 5, 6, 7], 3, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+    });
+
+    expect(peak).toBe(3);
+  });
+
+  it('handles an empty list and clamps invalid concurrency', async () => {
+    await expect(mapWithConcurrency([], 3, jest.fn())).resolves.toEqual([]);
+    await expect(
+      mapWithConcurrency([1, 2], 0, (value) => Promise.resolve(value * 2)),
+    ).resolves.toEqual([2, 4]);
+  });
+});

--- a/src/daily-brief/utils/concurrency.ts
+++ b/src/daily-brief/utils/concurrency.ts
@@ -1,0 +1,30 @@
+/**
+ * 按固定并发上限依次处理数组，结果顺序与输入保持一致。
+ * 用于避免一次性把所有外部请求打出去触发对方限流。
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const limit = Math.max(1, Math.floor(concurrency) || 1);
+  if (items.length === 0) {
+    return [];
+  }
+
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await mapper(items[index], index);
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  );
+
+  return results;
+}

--- a/src/database/repositories/daily-brief.repository.spec.ts
+++ b/src/database/repositories/daily-brief.repository.spec.ts
@@ -2,30 +2,35 @@ import { DailyBriefRepository } from './daily-brief.repository';
 
 describe('DailyBriefRepository stock ranking', () => {
   const aggregate = jest.fn();
+  const countDocuments = jest.fn();
   let repository: DailyBriefRepository;
 
   beforeEach(() => {
     aggregate.mockReset();
-    repository = new DailyBriefRepository({ aggregate } as never);
+    countDocuments.mockReset().mockResolvedValue(0);
+    repository = new DailyBriefRepository({
+      aggregate,
+      countDocuments,
+    } as never);
   });
 
   it('builds the history filters and maps aggregation results', async () => {
     aggregate.mockResolvedValue([
       {
-        briefs: [{ totalBriefs: 3 }],
         summary: [{ uniqueStocks: 1, totalAppearances: 4 }],
         rankings: [
           {
             company: '待验证',
             code: '600000',
             appearanceCount: 4,
-            briefIds: ['brief-1', 'brief-2'],
+            briefCount: 2,
             firstAppearedDate: '2026-07-01',
             lastAppearedDate: '2026-07-02',
           },
         ],
       },
     ]);
+    countDocuments.mockResolvedValue(3);
 
     const result = await repository.getStockRanking({
       period: 'daily',
@@ -34,16 +39,18 @@ describe('DailyBriefRepository stock ranking', () => {
       limit: 10,
     });
 
+    const expectedMatch = {
+      status: 'success',
+      period: 'daily',
+      briefDate: { $gte: '2026-07-01', $lte: '2026-07-31' },
+    };
     const pipeline = aggregate.mock.calls[0][0] as Array<
       Record<string, unknown>
     >;
-    expect(pipeline[0]).toEqual({
-      $match: {
-        status: 'success',
-        period: 'daily',
-        briefDate: { $gte: '2026-07-01', $lte: '2026-07-31' },
-      },
-    });
+    expect(pipeline[0]).toEqual({ $match: expectedMatch });
+    // 简报总数改用 countDocuments，与聚合共用同一份筛选条件
+    expect(countDocuments).toHaveBeenCalledWith(expectedMatch);
+
     const serializedPipeline = JSON.stringify(pipeline);
     expect(serializedPipeline).not.toContain('"$replaceAll"');
     expect(serializedPipeline).not.toContain('"$set"');
@@ -66,14 +73,140 @@ describe('DailyBriefRepository stock ranking', () => {
     });
   });
 
+  it('groups outside of $facet and never repeats the unwind', async () => {
+    aggregate.mockResolvedValue([{ summary: [], rankings: [] }]);
+
+    await repository.getStockRanking();
+
+    const pipeline = aggregate.mock.calls[0][0] as Array<
+      Record<string, unknown>
+    >;
+    // 两轮分组：先按公司名归并，再按归一化后的代码归并
+    expect(pipeline.filter((stage) => '$group' in stage)).toHaveLength(2);
+    // 两次 unwind 只在展开 topics/aShareMapping 时发生
+    expect(pipeline.filter((stage) => '$unwind' in stage)).toHaveLength(2);
+
+    const facetStage = pipeline.find((stage) => '$facet' in stage) as {
+      $facet: Record<string, Array<Record<string, unknown>>>;
+    };
+    expect(Object.keys(facetStage.$facet)).toEqual(['summary', 'rankings']);
+    // 两个分支都不再重复 unwind
+    expect(JSON.stringify(facetStage.$facet).includes('"$unwind"')).toBe(false);
+    // briefIds 只用于算 briefCount，不应出现在返回投影里
+    const rankingProjection = facetStage.$facet.rankings.find(
+      (stage) => '$project' in stage,
+    );
+    expect(rankingProjection).toEqual({
+      $project: {
+        _id: 0,
+        company: 1,
+        code: 1,
+        appearanceCount: 1,
+        briefCount: 1,
+        firstAppearedDate: 1,
+        lastAppearedDate: 1,
+      },
+    });
+  });
+
   it('returns an empty summary when no brief matches', async () => {
-    aggregate.mockResolvedValue([{ briefs: [], summary: [], rankings: [] }]);
+    aggregate.mockResolvedValue([{ summary: [], rankings: [] }]);
+    countDocuments.mockResolvedValue(0);
 
     await expect(repository.getStockRanking()).resolves.toEqual({
       totalBriefs: 0,
       uniqueStocks: 0,
       totalAppearances: 0,
       rankings: [],
+    });
+  });
+});
+
+describe('DailyBriefRepository list', () => {
+  const aggregate = jest.fn();
+  const countDocuments = jest.fn();
+  let repository: DailyBriefRepository;
+
+  beforeEach(() => {
+    aggregate.mockReset().mockResolvedValue([]);
+    countDocuments.mockReset().mockResolvedValue(0);
+    repository = new DailyBriefRepository({
+      aggregate,
+      countDocuments,
+    } as never);
+  });
+
+  it('projects only the summary fields and computes topicCount in MongoDB', async () => {
+    await repository.list({ page: 2, limit: 5, status: 'success' });
+
+    const pipeline = aggregate.mock.calls[0][0] as Array<
+      Record<string, unknown>
+    >;
+    expect(pipeline).toEqual([
+      { $match: { status: 'success' } },
+      { $sort: { briefDate: -1, createdAt: -1 } },
+      { $skip: 5 },
+      { $limit: 5 },
+      {
+        $project: {
+          _id: 0,
+          status: 1,
+          briefDate: 1,
+          period: 1,
+          analysis: {
+            summary: { $ifNull: ['$analysis.summary', '$$REMOVE'] },
+          },
+          topicCount: {
+            $cond: [
+              { $isArray: '$analysis.topics' },
+              { $size: '$analysis.topics' },
+              '$$REMOVE',
+            ],
+          },
+          updatedAt: 1,
+        },
+      },
+    ]);
+    // markdown 和 analysis.topics 不应被读出来
+    const serialized = JSON.stringify(pipeline);
+    expect(serialized).not.toContain('markdown');
+    expect(serialized).not.toContain('rawInputItems');
+  });
+
+  it('clamps paging and returns pagination metadata', async () => {
+    aggregate.mockResolvedValue([
+      {
+        status: 'success',
+        briefDate: '2026-07-01',
+        period: 'daily',
+        analysis: { summary: '结论' },
+        topicCount: 3,
+      },
+    ]);
+    countDocuments.mockResolvedValue(42);
+
+    const result = await repository.list({ page: 0, limit: 1000 });
+
+    const pipeline = aggregate.mock.calls[0][0] as Array<
+      Record<string, unknown>
+    >;
+    expect(pipeline[0]).toEqual({ $match: {} });
+    expect(pipeline).toContainEqual({ $skip: 0 });
+    expect(pipeline).toContainEqual({ $limit: 100 });
+    expect(result).toEqual({
+      data: [
+        {
+          status: 'success',
+          briefDate: '2026-07-01',
+          period: 'daily',
+          analysis: { summary: '结论' },
+          topicCount: 3,
+        },
+      ],
+      total: 42,
+      page: 1,
+      limit: 100,
+      totalPages: 1,
     });
   });
 });

--- a/src/database/repositories/daily-brief.repository.ts
+++ b/src/database/repositories/daily-brief.repository.ts
@@ -3,12 +3,45 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model, PipelineStage } from 'mongoose';
 import { DailyBrief, DailyBriefDocument } from '../schemas/daily-brief.schema';
 
+/** AI 可能给出的占位值，等同于「没有填」。 */
+const INVALID_VALUES = ['', '待验证', '未知', 'N/A', '-'];
+
+/** A 股代码可能带的交易所前缀。 */
+const MARKET_PREFIXES = ['SH', 'SZ', 'BJ'];
+
+/**
+ * 取数组里最后一个非 null 的值，没有则返回空字符串。
+ * 上游按 briefDate 升序排过，所以「最后一个」就是最近一次出现的值。
+ */
+const lastValidValue = (field: string) => ({
+  $let: {
+    vars: {
+      valid: {
+        $filter: {
+          input: field,
+          // 两轮分组分别会塞进 null 和空串，这里一并过滤
+          cond: { $not: [{ $in: ['$$this', [null, ...INVALID_VALUES]] }] },
+        },
+      },
+    },
+    in: { $ifNull: [{ $arrayElemAt: ['$$valid', -1] }, ''] },
+  },
+});
+
 export interface DailyBriefListOptions {
   page?: number;
   limit?: number;
   status?: 'generating' | 'success' | 'failed';
   period?: string;
-  includeDebug?: boolean;
+}
+
+export interface DailyBriefListItem {
+  status: 'generating' | 'success' | 'failed';
+  briefDate: string;
+  period: string;
+  analysis: { summary?: string };
+  topicCount?: number;
+  updatedAt?: Date;
 }
 
 interface DeleteBriefResult {
@@ -32,13 +65,12 @@ export interface StockRankingItem {
 }
 
 interface StockRankingAggregationResult {
-  briefs: Array<{ totalBriefs: number }>;
   summary: Array<{ uniqueStocks: number; totalAppearances: number }>;
   rankings: Array<{
     company: string;
     code?: string;
     appearanceCount: number;
-    briefIds: unknown[];
+    briefCount: number;
     firstAppearedDate: string;
     lastAppearedDate: string;
   }>;
@@ -80,7 +112,7 @@ export class DailyBriefRepository {
   async list(options: DailyBriefListOptions = {}) {
     const page = Math.max(1, options.page || 1);
     const limit = Math.min(100, Math.max(1, options.limit || 20));
-    const { status, period, includeDebug } = options;
+    const { status, period } = options;
     const query: Record<string, unknown> = {};
 
     if (status) {
@@ -91,34 +123,39 @@ export class DailyBriefRepository {
     }
 
     const skip = (page - 1) * limit;
+    // 列表只需要摘要和主题数量，用投影把 analysis.topics / markdown 留在数据库侧，
+    // 避免为了算一个 length 就把整份简报读出来。
     const [data, total] = await Promise.all([
-      this.dailyBriefModel
-        .find(query, includeDebug ? undefined : this.publicProjection)
-        .sort({ briefDate: -1, createdAt: -1 })
-        .skip(skip)
-        .limit(limit)
-        .lean(),
+      this.dailyBriefModel.aggregate<DailyBriefListItem>([
+        { $match: query },
+        { $sort: { briefDate: -1, createdAt: -1 } },
+        { $skip: skip },
+        { $limit: limit },
+        {
+          $project: {
+            _id: 0,
+            status: 1,
+            briefDate: 1,
+            period: 1,
+            analysis: {
+              summary: { $ifNull: ['$analysis.summary', '$$REMOVE'] },
+            },
+            topicCount: {
+              $cond: [
+                { $isArray: '$analysis.topics' },
+                { $size: '$analysis.topics' },
+                '$$REMOVE',
+              ],
+            },
+            updatedAt: 1,
+          },
+        },
+      ]),
       this.dailyBriefModel.countDocuments(query),
     ]);
 
-    // 返回的数据处理
-    const resData = data.map((item) => {
-      const topics = item.analysis?.topics;
-
-      return {
-        status: item.status,
-        briefDate: item.briefDate,
-        period: item.period,
-        analysis: {
-          summary: item.analysis?.summary,
-        },
-        topicCount: Array.isArray(topics) ? topics.length : undefined,
-        updatedAt: item.updatedAt,
-      };
-    });
-
     return {
-      data: resData,
+      data,
       total,
       page,
       limit,
@@ -142,7 +179,7 @@ export class DailyBriefRepository {
       match.briefDate = briefDate;
     }
 
-    const stockOccurrences: PipelineStage.FacetPipelineStage[] = [
+    const stockOccurrences: PipelineStage[] = [
       {
         $project: {
           briefId: '$_id',
@@ -208,57 +245,149 @@ export class DailyBriefRepository {
           },
         },
       },
+      // 归一化股票代码：去掉 `.SH` 之类的后缀和 `SH`/`SZ`/`BJ` 前缀，
+      // 让 600519 / SH600519 / 600519.SH 归到同一只股票。
+      // MongoDB 4.0 没有 $regexFind，这里只用字符串切分实现。
       {
         $addFields: {
-          identity: {
-            $cond: [
-              {
-                $not: [{ $in: ['$code', ['', '待验证', '未知', 'N/A', '-']] }],
+          code: {
+            $let: {
+              vars: {
+                base: { $arrayElemAt: [{ $split: ['$code', '.'] }, 0] },
               },
-              { $concat: ['code:', '$code'] },
-              {
-                $cond: [
-                  {
-                    $not: [
+              in: {
+                $let: {
+                  vars: {
+                    prefix: { $substrCP: ['$$base', 0, 2] },
+                    rest: {
+                      $substrCP: ['$$base', 2, { $strLenCP: '$$base' }],
+                    },
+                  },
+                  in: {
+                    $cond: [
                       {
-                        $in: ['$company', ['', '待验证', '未知', 'N/A', '-']],
+                        $and: [
+                          { $in: ['$$prefix', MARKET_PREFIXES] },
+                          { $eq: [{ $strLenCP: '$$rest' }, 6] },
+                        ],
                       },
+                      '$$rest',
+                      '$$base',
                     ],
                   },
-                  { $concat: ['company:', '$company'] },
-                  '',
-                ],
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        $addFields: {
+          hasValidCompany: { $not: [{ $in: ['$company', INVALID_VALUES] }] },
+          hasValidCode: { $not: [{ $in: ['$code', INVALID_VALUES] }] },
+        },
+      },
+      {
+        // 先按公司名归并：同一家公司在不同简报里可能有时带代码、有时不带，
+        // 只有先聚到一起才能把「有代码」的那次学到的代码补给「没代码」的那些。
+        $addFields: {
+          groupKey: {
+            $cond: [
+              '$hasValidCompany',
+              { $concat: ['company:', '$company'] },
+              {
+                $cond: ['$hasValidCode', { $concat: ['code:', '$code'] }, ''],
               },
             ],
           },
         },
       },
-      { $match: { identity: { $ne: '' } } },
-    ];
-    const groupedStocks: PipelineStage.FacetPipelineStage[] = [
-      ...stockOccurrences,
-      {
-        $group: {
-          _id: '$identity',
-          company: { $last: '$company' },
-          code: { $last: '$code' },
-          appearanceCount: { $sum: 1 },
-          briefIds: { $addToSet: '$briefId' },
-          firstAppearedDate: { $min: '$briefDate' },
-          lastAppearedDate: { $max: '$briefDate' },
-        },
-      },
+      { $match: { groupKey: { $ne: '' } } },
     ];
     const limit = Math.min(200, Math.max(1, options.limit || 50));
-    const [result] =
-      await this.dailyBriefModel.aggregate<StockRankingAggregationResult>([
+    // 分组只跑一遍：summary 和 rankings 从同一份聚合结果分叉，
+    // 简报总数用一次 countDocuments 并行取，不必为它保留原始文档。
+    const [[result], totalBriefs] = await Promise.all([
+      this.dailyBriefModel.aggregate<StockRankingAggregationResult>([
         { $match: match },
+        // $last 依赖这个顺序来取每只股票最新出现时的名称和代码
         { $sort: { briefDate: 1, createdAt: 1 } },
+        ...stockOccurrences,
+        // 第一轮：按公司名（无公司名时按代码）聚合，顺带收集出现过的代码和名称
+        {
+          $group: {
+            _id: '$groupKey',
+            companies: {
+              $push: { $cond: ['$hasValidCompany', '$company', null] },
+            },
+            codes: { $push: { $cond: ['$hasValidCode', '$code', null] } },
+            appearanceCount: { $sum: 1 },
+            briefIds: { $addToSet: '$briefId' },
+            firstAppearedDate: { $min: '$briefDate' },
+            lastAppearedDate: { $max: '$briefDate' },
+          },
+        },
+        {
+          // 取最近一次出现时的有效代码/名称（上游已按 briefDate 升序排过）
+          $addFields: {
+            company: lastValidValue('$companies'),
+            resolvedCode: lastValidValue('$codes'),
+          },
+        },
+        {
+          // 学到代码的公司改用代码作为身份，于是「有代码」和「没代码」的
+          // 同一家公司、以及只有代码没有名称的记录，都会并到同一条上。
+          $addFields: {
+            identity: {
+              $cond: [
+                { $eq: ['$resolvedCode', ''] },
+                '$_id',
+                { $concat: ['code:', '$resolvedCode'] },
+              ],
+            },
+          },
+        },
+        { $sort: { lastAppearedDate: 1 } },
+        // 第二轮：把归并到同一身份的分组合并成最终结果
+        {
+          $group: {
+            _id: '$identity',
+            companies: { $push: '$company' },
+            code: { $last: '$resolvedCode' },
+            appearanceCount: { $sum: '$appearanceCount' },
+            briefIdGroups: { $push: '$briefIds' },
+            firstAppearedDate: { $min: '$firstAppearedDate' },
+            lastAppearedDate: { $max: '$lastAppearedDate' },
+          },
+        },
+        {
+          $addFields: {
+            company: lastValidValue('$companies'),
+            // 跨分组去重后才是真实的简报数
+            briefCount: {
+              $size: {
+                $reduce: {
+                  input: '$briefIdGroups',
+                  initialValue: [],
+                  in: { $setUnion: ['$$value', '$$this'] },
+                },
+              },
+            },
+          },
+        },
+        // 中间字段只用于计算，尽早丢弃避免传输大量 ObjectId
+        {
+          $project: {
+            briefIdGroups: 0,
+            briefIds: 0,
+            companies: 0,
+            codes: 0,
+            resolvedCode: 0,
+          },
+        },
         {
           $facet: {
-            briefs: [{ $count: 'totalBriefs' }],
             summary: [
-              ...groupedStocks,
               {
                 $group: {
                   _id: null,
@@ -269,12 +398,6 @@ export class DailyBriefRepository {
               { $project: { _id: 0, uniqueStocks: 1, totalAppearances: 1 } },
             ],
             rankings: [
-              ...groupedStocks,
-              {
-                $addFields: {
-                  briefCount: { $size: '$briefIds' },
-                },
-              },
               {
                 $sort: {
                   appearanceCount: -1,
@@ -291,7 +414,7 @@ export class DailyBriefRepository {
                   company: 1,
                   code: 1,
                   appearanceCount: 1,
-                  briefIds: 1,
+                  briefCount: 1,
                   firstAppearedDate: 1,
                   lastAppearedDate: 1,
                 },
@@ -299,12 +422,14 @@ export class DailyBriefRepository {
             ],
           },
         },
-      ]);
+      ]),
+      this.dailyBriefModel.countDocuments(match),
+    ]);
 
     const summary = result?.summary[0];
-    const invalidNames = new Set(['', '待验证', '未知', 'N/A', '-']);
+    const invalidNames = new Set(INVALID_VALUES);
     return {
-      totalBriefs: result?.briefs[0]?.totalBriefs || 0,
+      totalBriefs,
       uniqueStocks: summary?.uniqueStocks || 0,
       totalAppearances: summary?.totalAppearances || 0,
       rankings: (result?.rankings || []).map(
@@ -314,7 +439,7 @@ export class DailyBriefRepository {
             : item.company,
           code: item.code || null,
           appearanceCount: item.appearanceCount,
-          briefCount: item.briefIds.length,
+          briefCount: item.briefCount,
           firstAppearedDate: item.firstAppearedDate,
           lastAppearedDate: item.lastAppearedDate,
         }),

--- a/src/database/repositories/mongo40-compatibility.spec.ts
+++ b/src/database/repositories/mongo40-compatibility.spec.ts
@@ -1,0 +1,153 @@
+import { DailyBriefRepository } from './daily-brief.repository';
+
+/**
+ * 部署目标是 MongoDB 4.0，这里守住聚合管道不引入 4.2+ 才提供的算子。
+ * 之前出现过因为用了 `$set` / `$replaceAll` 导致线上报错的情况。
+ */
+
+// 4.2 新增
+const STAGES_4_2 = ['$set', '$unset', '$replaceWith', '$merge'];
+const EXPRS_4_2 = [
+  '$replaceAll',
+  '$replaceOne',
+  '$regexFind',
+  '$regexFindAll',
+  '$regexMatch',
+  '$round',
+];
+// 4.4 新增
+const STAGES_4_4 = ['$unionWith', '$planCacheStats'];
+const EXPRS_4_4 = ['$accumulator', '$function', '$isNumber', '$binarySize'];
+// 5.0+ 新增
+const STAGES_5_PLUS = ['$setWindowFields', '$densify', '$fill', '$documents'];
+const EXPRS_5_PLUS = [
+  '$dateAdd',
+  '$dateSubtract',
+  '$dateDiff',
+  '$dateTrunc',
+  '$getField',
+  '$setField',
+  '$rand',
+  '$sortArray',
+  '$maxN',
+  '$minN',
+  '$firstN',
+  '$lastN',
+  '$median',
+  '$percentile',
+];
+
+const FORBIDDEN = [
+  ...STAGES_4_2,
+  ...EXPRS_4_2,
+  ...STAGES_4_4,
+  ...EXPRS_4_4,
+  ...STAGES_5_PLUS,
+  ...EXPRS_5_PLUS,
+];
+
+/** 收集管道里出现的所有 `$` 开头的键名。 */
+const collectOperators = (node: unknown, found = new Set<string>()) => {
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectOperators(child, found));
+    return found;
+  }
+  if (node && typeof node === 'object') {
+    for (const [key, value] of Object.entries(node)) {
+      if (key.startsWith('$')) {
+        found.add(key);
+      }
+      collectOperators(value, found);
+    }
+  }
+  return found;
+};
+
+describe('daily brief aggregation pipelines stay MongoDB 4.0 compatible', () => {
+  const capturedPipelines: unknown[][] = [];
+  const aggregate = jest.fn((pipeline: unknown[]) => {
+    capturedPipelines.push(pipeline);
+    return Promise.resolve([{ summary: [], rankings: [] }]);
+  });
+  const countDocuments = jest.fn().mockResolvedValue(0);
+
+  beforeAll(async () => {
+    const repository = new DailyBriefRepository({
+      aggregate,
+      countDocuments,
+    } as never);
+
+    // 覆盖两条管道的全部分支：带筛选和不带筛选
+    await repository.getStockRanking({
+      period: 'daily',
+      startDate: '2026-07-01',
+      endDate: '2026-07-31',
+      limit: 10,
+    });
+    await repository.getStockRanking();
+    await repository.list({ status: 'success', period: 'daily' });
+    await repository.list({});
+  });
+
+  it('captures both pipelines', () => {
+    expect(capturedPipelines).toHaveLength(4);
+  });
+
+  it.each(FORBIDDEN)('does not use %s', (operator) => {
+    const used = capturedPipelines.flatMap((pipeline) => [
+      ...collectOperators(pipeline),
+    ]);
+    expect(used).not.toContain(operator);
+  });
+
+  it('only uses operators available in MongoDB 4.0', () => {
+    // 4.0 及更早版本即可用的算子白名单（含 $trim / $convert，二者正是 4.0 引入）
+    const allowed = new Set([
+      '$match',
+      '$project',
+      '$group',
+      '$sort',
+      '$limit',
+      '$skip',
+      '$unwind',
+      '$addFields',
+      '$facet',
+      '$sum',
+      '$min',
+      '$max',
+      '$last',
+      '$addToSet',
+      '$size',
+      '$concat',
+      '$cond',
+      '$ifNull',
+      '$in',
+      '$not',
+      '$ne',
+      '$gte',
+      '$lte',
+      '$isArray',
+      '$reduce',
+      '$split',
+      '$trim',
+      '$convert',
+      '$toUpper',
+      // 股票代码归一化与两轮分组（均为 3.2/3.4 引入，4.0 可用）
+      '$let',
+      '$filter',
+      '$push',
+      '$and',
+      '$eq',
+      '$arrayElemAt',
+      '$substrCP',
+      '$strLenCP',
+      '$setUnion',
+    ]);
+
+    const used = new Set(
+      capturedPipelines.flatMap((pipeline) => [...collectOperators(pipeline)]),
+    );
+    const unexpected = [...used].filter((operator) => !allowed.has(operator));
+    expect(unexpected).toEqual([]);
+  });
+});

--- a/src/database/schemas/daily-brief.schema.ts
+++ b/src/database/schemas/daily-brief.schema.ts
@@ -69,3 +69,11 @@ export const DailyBriefSchema = SchemaFactory.createForClass(DailyBrief);
 
 DailyBriefSchema.index({ briefDate: 1, period: 1 }, { unique: true });
 DailyBriefSchema.index({ createdAt: -1 });
+
+// list()：默认排序 { briefDate: -1, createdAt: -1 }，query 可能为空
+DailyBriefSchema.index({ briefDate: -1, createdAt: -1 });
+// findLatest()：{ status: 'success' } + 同样的排序；
+// 也覆盖 getStockRanking 不带 period 时的 { status, briefDate } 匹配（反向扫描）
+DailyBriefSchema.index({ status: 1, briefDate: -1, createdAt: -1 });
+// getStockRanking()：{ status, period, briefDate 区间 } + { briefDate: 1, createdAt: 1 } 排序
+DailyBriefSchema.index({ status: 1, period: 1, briefDate: 1, createdAt: 1 });


### PR DESCRIPTION
对 `daily-brief` 模块做了一轮完整评审，修复了发现的全部 18 个问题。改动按主题分成 2 个 commit（缓存模块的 SCAN 改动单独一个，因为它影响全项目而不只是简报模块）。

## 为什么

评审中发现的问题里，有几个会直接导致线上故障或数据错误，其余是性能与可维护性问题。详见下面分类。

## 改了什么

### 缺陷修复

| 问题 | 影响 |
| --- | --- |
| `mergeAndLimitItems` 无参调用 `resolveSources()` | 自定义 `sources` 时条目上限按**配置的**源数算，导致截断或超量 |
| `generating` 状态没有超时 | 进程在生成中被中断，该日期**永久锁死**：所有非 `force` 请求抛 400，定时任务也无法恢复，只能人工删文档 |
| zod schema 每个字段都带 `.catch()` | AI 返回 `{}` 也能解析成功，**空简报被标记为 success 写库**，无任何告警 |
| `getConfig` 直读配置而调度器状态在内存 | `POST /scheduler/start` 之后 `GET /config` 仍报 `enabled: false` |
| 排行榜 identity 规则 | 同一家公司被**拆成多条**，计数全错 |

排行榜那条是两个独立缺陷叠加：代码格式变体（`600519` / `SH600519` / `600519.SH` 各算一只），以及同一公司有时带代码、有时不带（拆成两条）。现在先归一化代码，再用两轮分组把「带代码那次」学到的代码补给同一公司的其他记录。

### 外部调用加固

- Tavily 与 OpenAI **此前都没有超时**。SDK 默认 10 分钟 + 2 次重试，最坏挂住半小时；叠加上面的 `generating` 缺陷会让模块彻底停摆。现在均可配置。
- Tavily 搜索此前是 12 路无限流 `Promise.all`（易触发限流，失败被静默吞掉），热榜源抓取则是完全串行。两者都改为受限并发。

### 读放大

- `list()` 此前把 `analysis.topics` 和 `markdown` 整份读出来，只为在 JS 里取 `summary` 和 `topics.length`。改为投影聚合，`topicCount` 用 `$size` 在库侧算。
- 排行榜的两次 `$unwind` + `$group` 在 `$facet` 的两个分支里各跑一遍，成本翻倍；且已算出 `briefCount` 却投影了整片 `briefIds` 回应用层。现在分组只跑一遍。
- 补了 3 个复合索引。`explain` 确认 `findLatest` 现在走 `IXSCAN` 且**没有 SORT 阶段**。

### 重构

- 新增 `DailyBriefConfigService` 作为模块唯一配置入口。此前同一个默认值散落在 **34 个调用点**（`BRIEF_TIMEZONE` 重复 5 次、`BRIEF_TOP_ITEMS_PER_SOURCE` 4 次），改一处漏一处。现在用 `getOrThrow`，默认值只存在于 `configuration.ts` / `validation.schema.ts`。
- 手写的 `Intl` 时区偏移计算（约 50 行）换成 dayjs。
- `GET /:date` 不再把任意字符串打到 Mongo；列表的 `status` 传非法值返回 400 而不是静默空结果。
- 顺带修了一个潜在 bug：`OPENAI_API_BASE_URL` 未配置时会把**空字符串**传给 OpenAI SDK，而 SDK 用 `??` 兜底，空串会被当成真实 baseURL。

## MongoDB 4.0 兼容性

仓库此前有过 4.0 不兼容导致线上出错的记录，所以本次专门验证了：

- 在**真实的 mongod 4.0.28** 上跑了两条重写后的管道、索引建立、以及归并语义（12 项断言覆盖三种代码写法、有无代码混用、只有代码没名称、同简报内重复、完全无效项）。
- 新增 `mongo40-compatibility.spec.ts`：提取管道实际发出的全部算子，黑名单挡住 4.2/4.4/5.0 算子，**白名单**挡住未经确认的新算子。原来的守护只有两行字符串断言（`$set` / `$replaceAll`），且只覆盖一条管道。

天花板仍是原本就有的 `$trim` / `$convert`（均为 4.0 引入），没有抬高最低版本要求。

## 验证

- 测试从 **5 个增加到 83 个**。
- `npm run build`、`npx eslint "src/**/*.ts"`、`prettier --check` 全部通过。
- 启动真实服务验证了 DI 接线、参数校验的 HTTP 状态码，以及 `scheduler/start|stop` 与 `/config` 的一致性。
- `delByPattern` 的 SCAN 改动对真实 Redis 验证：250 个跨批次的目标 key 全删，同命名空间下其他前缀未误伤。

## Reviewer 需要知道的

1. **`GET /api/briefs` 移除了 `includeDebug` 参数**。它在该接口上本来就完全无效（响应结构不受影响，只是多读数据再丢弃），文档里也只为 `latest` 和 `:date` 记载过。这是唯一的对外行为变更。
2. **排行榜归并逻辑是聚合管道语义，mock 测试证明不了它**。仓库现有 spec 全是 mock，没有集成测试基建，所以单测只断言管道结构，真正的行为验证靠手动跑 MongoDB 4.0。如果希望这条进 CI，需要引入 `mongodb-memory-server`。
3. **索引只新增、未删除**。`briefDate` / `period` / `status` 三个单字段索引现在有冗余（`briefDate` 已被 `{briefDate, period}` unique 索引前缀覆盖），但从 schema 删除声明不会 drop 线上已建索引，只会造成代码与实际不一致。清理需要一次显式的 `dropIndex` 运维操作。
4. **写接口仍无鉴权**，这是维护者明确的决定（在反向代理层处理）。已在 `docs/guide/daily-brief.md` 加了告警块列出需要在网关层挡住的 6 个接口，并在 `AGENTS.md` 注明不要擅自加鉴权。
5. **`BRIEF_STOCK_RANKING_CACHE_TTL` 现在有 `.min(1)` 校验**，非法值会在启动时报错而不是运行期静默替换成默认值。
6. `app.controller.spec.ts` 是**既有失败**（启动整个 AppModule 需要 Redis/Mongo），在干净的 main 上同样复现，与本次改动无关，未做改动。

## 新增环境变量

6 个，均有默认值，**现有部署无需改动 `.env` 即可运行**。已按 `AGENTS.md` 的约定同步到 `configuration.ts`、`validation.schema.ts`、`.env.example`。

```
BRIEF_GENERATING_TIMEOUT_MINUTES=30
BRIEF_SOURCE_CONCURRENCY=3
BRIEF_SEARCH_CONCURRENCY=3
AI_TIMEOUT_MS=120000
AI_MAX_RETRIES=2
TAVILY_TIMEOUT_MS=10000
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)